### PR TITLE
fix(firefox): restore background and storage compatibility

### DIFF
--- a/src/core/diagnostics.ts
+++ b/src/core/diagnostics.ts
@@ -72,7 +72,7 @@ let cachedStorage: AsyncKV | null | undefined;
 function getStorage(): AsyncKV | null {
   if (cachedStorage !== undefined) return cachedStorage;
   try {
-    const c = (globalThis as any).chrome;
+    const c = (globalThis as any).browser;
     if (c?.storage?.local) {
       cachedStorage = {
         get: (k) => c.storage.local.get(k).then((r: any) => r[k]),
@@ -82,7 +82,7 @@ function getStorage(): AsyncKV | null {
     }
   } catch { /* fall through */ }
   try {
-    const b = (globalThis as any).browser;
+    const b = (globalThis as any).chrome;
     if (b?.storage?.local) {
       cachedStorage = {
         get: (k) => b.storage.local.get(k).then((r: any) => r[k]),

--- a/src/extension/background/background-firefox.html
+++ b/src/extension/background/background-firefox.html
@@ -6,6 +6,6 @@
 </head>
 <body>
   <script src="ort.min.js"></script>
-  <script src="background.js"></script>
+  <script type="module" src="background-firefox.ts"></script>
 </body>
 </html>

--- a/src/extension/model-store.ts
+++ b/src/extension/model-store.ts
@@ -18,18 +18,17 @@ let cachedStorage: any = null;
 
 function getStorage(): any {
   if (cachedStorage) return cachedStorage;
-  // chrome first — this module is bundled into both Chrome MV3 (offscreen/background/options) and
-  // Firefox MV2 builds. In Chrome contexts `browser` is occasionally polyfilled by other extensions
-  // as a Proxy that throws on property access, so wrap each probe in try/catch.
+  // Prefer Firefox's Promise-based browser.storage in MV2 builds, then fall back to chrome.storage
+  // for Chromium. Wrap each probe in try/catch because some contexts expose throwing proxies.
   try {
-    if (typeof chrome !== 'undefined' && chrome?.storage?.local) {
-      cachedStorage = chrome.storage.local;
+    if (typeof browser !== 'undefined' && browser?.storage?.local) {
+      cachedStorage = browser.storage.local;
       return cachedStorage;
     }
   } catch { /* fall through */ }
   try {
-    if (typeof browser !== 'undefined' && browser?.storage?.local) {
-      cachedStorage = browser.storage.local;
+    if (typeof chrome !== 'undefined' && chrome?.storage?.local) {
+      cachedStorage = chrome.storage.local;
       return cachedStorage;
     }
   } catch { /* fall through */ }

--- a/src/extension/subscription-manager.ts
+++ b/src/extension/subscription-manager.ts
@@ -15,19 +15,19 @@ declare const browser: any;
 
 let cachedStorage: any = null;
 
-// Lazy storage shim — defers global access until first use, prefers chrome (this is also
-// the Chrome MV3 build), and guards against `browser` polyfills that throw on property access.
+// Lazy storage shim — defers global access until first use. Prefer Firefox's Promise-based
+// browser.storage in Firefox builds, then fall back to chrome.storage for Chromium.
 function getStorage(): any {
   if (cachedStorage) return cachedStorage;
   try {
-    if (typeof chrome !== 'undefined' && chrome?.storage?.local) {
-      cachedStorage = chrome.storage.local;
+    if (typeof browser !== 'undefined' && browser?.storage?.local) {
+      cachedStorage = browser.storage.local;
       return cachedStorage;
     }
   } catch { /* fall through */ }
   try {
-    if (typeof browser !== 'undefined' && browser?.storage?.local) {
-      cachedStorage = browser.storage.local;
+    if (typeof chrome !== 'undefined' && chrome?.storage?.local) {
+      cachedStorage = chrome.storage.local;
       return cachedStorage;
     }
   } catch { /* fall through */ }


### PR DESCRIPTION
修复 Firefox [1.2.0](vscode-file://vscode-app/c:/Users/gpud/AppData/Local/Programs/Microsoft%20VS%20Code/10c8e557c8/resources/app/out/vs/code/electron-browser/workbench/workbench.html) 扩展无法连接内容脚本的问题。

问题表现：

点击插件提示 Could not establish connection. Receiving end does not exist
无法识别验证码，也无法自动填写
修复内容：

将 Firefox 背景页改为模块方式加载背景脚本
Firefox 构建中优先使用 browser.storage，再回退到 chrome.storage
同步修复诊断模块中的存储适配顺序
验证：

npm run build:firefox 通过
npm run type-check 通过
web-ext lint 对 dist/firefox 校验为 0 errors